### PR TITLE
Distinguish pattern-based redirects from rewrites

### DIFF
--- a/scripts/config/lib/nginx_config.rb
+++ b/scripts/config/lib/nginx_config.rb
@@ -48,7 +48,7 @@ class NginxConfig
     json["routes"] ||= {}
     json["routes"] = NginxConfigUtil.parse_routes(json["routes"])
 
-    %w(rewrites redirects).each do |rule|
+    %w(redirects).each do |rule|
       json[rule] ||= {}
       json[rule].each do |loc, hash|
         json[rule][loc].merge!("url" => NginxConfigUtil.interpolate(hash["url"], ENV))

--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -120,7 +120,7 @@ http {
 
   # fallback rewrites pattern match
   <% rewrites.each do |pattern, hash| %>
-    location <%= pattern %> {
+    location ~ <%= pattern %> {
       rewrite <%= pattern %> <%= hash['target'] %>;
     }
   <% end %>

--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -111,10 +111,17 @@ http {
     }
   <% end %>
 
-  # fallback rewrites pattern match
-  <% rewrites.each do |path, hash| %>
+  # fallback redirects pattern match
+  <% pattern_redirects.each do |path, hash| %>
     location <%= path %> {
       return <%= hash['status'] || 301 %> <%= hash['url'] %>;
+    }
+  <% end %>
+
+  # fallback rewrites pattern match
+  <% rewrites.each do |pattern, hash| %>
+    location <%= pattern %> {
+      rewrite <%= pattern %> <%= hash['target'] %>;
     }
   <% end %>
 


### PR DESCRIPTION
This PR changes the data structure of static.json to enable a distinction 

*  `pattern_redirects` are now used to render nginx redirect rules which use patterns (previously these were inaccurately called `rewrites`
* `rewrites` are now rendered as nginx rewrite rules

example static.json:
<details>

```
{
  "root": "/app/public/",
  "https_only": true,
  "error_page": "/404.html",
  "pattern_redirects": {
    "~ ^/sensu-core/2.0/?(.*)$": {
      "url": "/sensu-go/latest/$1",
      "status": 301
    },
    "~ ^/sensu-go/latest/guides/create-a-ready-only-user$": {
      "url": "/sensu-go/latest/guides/create-read-only-user",
      "status": 301
    }
  },
  "rewrites": {
    "^/sensu-core/latest/?(.*)$": {
      "target": "/sensu-core/1.8/$1"
    },
    "^/uchiwa/latest/?(.*)$": {
      "target": "/uchiwa/1.0/$1"
    },
    "^/sensu-enterprise/latest/?(.*)$": {
      "target": "/sensu-enterprise/3.6/$1"
    },
    "^/sensu-enterprise-dashboard/latest/?(.*)$": {
      "target": "/sensu-enterprise-dashboard/2.16/$1"
    },
    "^/sensu-go/latest/?(.*)$": {
      "target": "/sensu-go/5.14/$1"
    },
    "^/plugins/latest/?(.*)$": {
      "target": "/plugins/1.0/$1"
    }
  }
}
```
</details>

renders as:
<details>

```
daemon off;
worker_processes auto;

events {
  use epoll;
  accept_mutex on;
  worker_connections 2048;
}

http {
  gzip on;
  gzip_comp_level 6;
  gzip_min_length 512;
  gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
  gzip_vary on;
  gzip_proxied any;

  server_tokens off;


  access_log logs/access.log;



  error_log stderr error;


  include mime.types;
  default_type application/octet-stream;
  sendfile on;

  #Must read the body in 5 seconds.
  client_body_timeout 5;

  server {
    listen 40045 reuseport;
    charset UTF-8;
    port_in_redirect off;
    keepalive_timeout 5;
    root /app/public/;
 

    error_page 404 500 //404.html;
  
  

    location / {
      mruby_post_read_handler /app/bin/config/lib/ngx_mruby/headers.rb cache;
      mruby_set $fallback /app/bin/config/lib/ngx_mruby/routes_fallback.rb cache;
    
      try_files $uri $uri/ $fallback;
   

    }

  

  
    if ($http_x_forwarded_proto != "https") {
      return 301 https://$host$request_uri;
    }
  

  

  # need this b/c setting $fallback to =404 will try #{root}=404 instead of returning a 404
  location @404 {
    return 404;
  }

  # fallback proxy named match
  

  # fallback redirects named match
  

  # fallback redirects pattern match
  
    location ~ ^/sensu-core/2.0/?(.*)$ {
      return 301 /sensu-go/latest/$1;
    }
  
    location ~ ^/sensu-go/latest/guides/create-a-ready-only-user$ {
      return 301 /sensu-go/latest/guides/create-read-only-user;
    }
  

  # fallback rewrites pattern match
  
    location ~ ^/sensu-core/latest/?(.*)$ {
      rewrite ^/sensu-core/latest/?(.*)$ /sensu-core/1.8/$1;
    }
  
    location ~ ^/uchiwa/latest/?(.*)$ {
      rewrite ^/uchiwa/latest/?(.*)$ /uchiwa/1.0/$1;
    }
  
    location ~ ^/sensu-enterprise/latest/?(.*)$ {
      rewrite ^/sensu-enterprise/latest/?(.*)$ /sensu-enterprise/3.6/$1;
    }
  
    location ~ ^/sensu-enterprise-dashboard/latest/?(.*)$ {
      rewrite ^/sensu-enterprise-dashboard/latest/?(.*)$ /sensu-enterprise-dashboard/2.16/$1;
    }
  
    location ~ ^/sensu-go/latest/?(.*)$ {
      rewrite ^/sensu-go/latest/?(.*)$ /sensu-go/5.14/$1;
    }
  
    location ~ ^/plugins/latest/?(.*)$ {
      rewrite ^/plugins/latest/?(.*)$ /plugins/1.0/$1;
    }
  

  }
}
```
</details>